### PR TITLE
[Fix] build error

### DIFF
--- a/fs/binfmt_misc.c
+++ b/fs/binfmt_misc.c
@@ -415,12 +415,12 @@ static int parse_command(const char __user *buffer, size_t count)
 {
 	char s[4];
 
-	if (!count)
-		return 0;
 	if (count > 3)
 		return -EINVAL;
 	if (copy_from_user(s, buffer, count))
 		return -EFAULT;
+	if (!count)
+		return 0;
 	if (s[count-1] == '\n')
 		count--;
 	if (count == 1 && s[0] == '0')

--- a/fs/namespace.c
+++ b/fs/namespace.c
@@ -2361,9 +2361,9 @@ SYSCALL_DEFINE5(mount, char __user *, dev_name, char __user *, dir_name,
 		char __user *, type, unsigned long, flags, void __user *, data)
 {
 	int ret;
-	char *kernel_type;
-	char *kernel_dir;
-	char *kernel_dev;
+	char *kernel_type = NULL;
+	char *kernel_dir = NULL;
+	char *kernel_dev = NULL;
 	unsigned long data_page;
 
 	ret = copy_mount_string(type, &kernel_type);


### PR DESCRIPTION
fs/namespace.c: In function 'sys_mount':
fs/namespace.c:2387:6: warning 'kernel_dev' may be used uninitialized in this function
